### PR TITLE
Feature: Configure Hound Pool

### DIFF
--- a/.dialyzer
+++ b/.dialyzer
@@ -1,5 +1,6 @@
-lib/data_daemon.ex:228: Function start_link/1 has no local return
-lib/data_daemon.ex:231: The call 'Elixir.Module':concat(_module@1::[atom() | tuple()],'Elixir.Supervisor') will never return since the success typing is (atom() | binary(),atom() | binary()) -> atom() and the contract is (binary() | atom(),binary() | atom()) -> atom()
+lib/data_daemon.ex:230: Function start_link/1 has no local return
+lib/data_daemon.ex:230: Function start_link/2 has no local return
+lib/data_daemon.ex:234: The call 'Elixir.DataDaemon.Hound':child_spec(_module@1::atom(),integer(),integer()) will never return since it differs in the 1st argument from the success typing arguments: ([atom() | tuple()],any(),any())
 lib/data_daemon/hound.ex:11: Invalid type specification for function 'Elixir.DataDaemon.Hound':child_spec/3. The success typing is ([atom() | tuple()],_,_) -> {_,{'poolboy','start_link',[any(),...]},'permanent',5000,'worker',['poolboy',...]}
 lib/data_daemon/hound.ex:212: The pattern 'false' can never match the type 'true'
 lib/data_daemon/extensions/data_dog.ex:55: The call 'Elixir.Logger':add_backend({'Elixir.DataDaemon.Extensions.DataDog.ErrorHandler',{_,_}}) will never return since it differs in the 1st argument from the success typing arguments: (atom())

--- a/lib/data_daemon/dev_daemon.ex
+++ b/lib/data_daemon/dev_daemon.ex
@@ -6,8 +6,8 @@ defmodule DataDaemon.LogDaemon do
   import Logger.Utils, only: [timestamp: 1]
 
   @doc false
-  @spec start_link(module) :: Supervisor.on_start()
-  def start_link(_module), do: {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+  @spec start_link(module, Keyword.t()) :: Supervisor.on_start()
+  def start_link(_module, _opts \\ []), do: {:ok, spawn(fn -> Process.sleep(:infinity) end)}
 
   @doc false
   @spec metric(module, DataDaemon.key(), DataDaemon.value(), DataDaemon.type(), Keyword.t()) ::

--- a/lib/data_daemon/test_daemon.ex
+++ b/lib/data_daemon/test_daemon.ex
@@ -3,8 +3,8 @@ defmodule DataDaemon.TestDaemon do
   import DataDaemon.Util, only: [package: 4]
 
   @doc false
-  @spec start_link(module) :: Supervisor.on_start()
-  def start_link(module),
+  @spec start_link(module, Keyword.t()) :: Supervisor.on_start()
+  def start_link(module, _opts \\ []),
     do: Agent.start_link(fn -> [] end, name: module)
 
   @doc false

--- a/lib/data_daemon/util.ex
+++ b/lib/data_daemon/util.ex
@@ -60,4 +60,11 @@ defmodule DataDaemon.Util do
       end
     )
   end
+
+  @doc ~S"""
+  Forces a value to integer.
+  """
+  @spec to_integer!(integer | String.t()) :: integer | no_return
+  def to_integer!(value) when is_integer(value), do: value
+  def to_integer!(value) when is_binary(value), do: String.to_integer(value)
 end

--- a/test/data_daemon_test.exs
+++ b/test/data_daemon_test.exs
@@ -3,22 +3,39 @@ defmodule DataDaemonTest do
 
   defmodule Example do
     use DataDaemon,
-      otp_app: :data_daemon
+      otp_app: :data_daemon,
+      hound: [
+        size: 2,
+        overflow: "10"
+      ]
   end
 
   test "child_spec/1" do
     assert DataDaemon.child_spec(Example)
   end
 
-  test "start_link/1" do
-    :meck.new(DataDaemon.Hound)
-    :meck.expect(DataDaemon.Hound, :child_spec, & &1)
+  describe "start_link/1" do
+    setup do
+      :meck.new(Supervisor)
+      :meck.expect(Supervisor, :start_link, fn [child], _opts -> child end)
+      on_exit(&:meck.unload/0)
+    end
 
-    :meck.new(Supervisor)
-    :meck.expect(Supervisor, :start_link, fn _, _ -> :ok end)
-    on_exit(&:meck.unload/0)
+    test "starts child spec" do
+      assert Example.start_link()
+    end
 
-    assert DataDaemon.start_link(Example)
+    test "parses configured pool (hound) size" do
+      {_, {:poolboy, :start_link, [opts | _]}, _, _, _, _} = Example.start_link()
+
+      assert opts[:size] == 2
+    end
+
+    test "parses configured pool (hound) overflow" do
+      {_, {:poolboy, :start_link, [opts | _]}, _, _, _, _} = Example.start_link()
+
+      assert opts[:max_overlow] == 10
+    end
   end
 
   test "metric/5" do


### PR DESCRIPTION
Allow configuration of `hound` pool in application configuration or module config.

Example:
```elixir
hound: [
  size: 2,
  overflow: 10
]
```

Strings are accepted and converted to integers.
This allows for setting through env vars.