### PR TITLE
Release: v0.2.1

### DIFF
--- a/.dialyzer
+++ b/.dialyzer
@@ -1,5 +1,5 @@
-lib/data_daemon.ex:241: Function start_link/1 has no local return
-lib/data_daemon.ex:241: Function start_link/2 has no local return
+lib/data_daemon.ex:251: Function start_link/1 has no local return
+lib/data_daemon.ex:251: Function start_link/2 has no local return
 lib/data_daemon/hound.ex:13: Function child_spec/1 has no local return
 lib/data_daemon/hound.ex:13: Function child_spec/2 has no local return
 lib/data_daemon/hound.ex:16: The call poolboy:child_spec(_pool@1::any(),[{'max_overflow',integer()} | {'name',{'local',_}} | {'size',integer()} | {'worker_module','Elixir.DataDaemon.Hound'},...],{_,'nil' | [{atom(),_}] | map()}) breaks the contract (PoolId::term(),PoolArgs::proplists:proplist(),WorkerArgs::proplists:proplist()) -> supervisor:child_spec()

--- a/README.md
+++ b/README.md
@@ -147,6 +147,22 @@ The following metrics are tracked:
 
 ## Changelog
 
+### 0.2.1 (2019-04-27)
+
+New features:
+
+* `:minimum_ttl` option to set a minimum TTL to prevent excessive refreshing. (Default: `1_000`)
+
+Optimizations:
+
+* `:erlang_vm` extension runs as additional child to restart during crashes.
+* Perform actual resolve in async process to prevent deadlock during excessive DNS refresh.
+* DNS resolves in separate process removing use of `:timer` and only sending an update to workers if `IP` changes.
+
+Bug fixes:
+
+* Fixes issue where the `:erlang_vm` would link its process not to the DataDaemon, but the calling process.
+
 ### 0.2.0 (2019-04-17)
 
 New features:

--- a/lib/data_daemon.ex
+++ b/lib/data_daemon.ex
@@ -242,6 +242,7 @@ defmodule DataDaemon do
     children = [
       Resolver.child_spec(module, opts),
       Hound.child_spec(module, opts)
+      | Keyword.get(opts, :children, [])
     ]
 
     opts = [strategy: :one_for_one, name: Module.concat(module, Supervisor)]

--- a/lib/data_daemon/dev_daemon.ex
+++ b/lib/data_daemon/dev_daemon.ex
@@ -7,7 +7,11 @@ defmodule DataDaemon.LogDaemon do
 
   @doc false
   @spec start_link(module, Keyword.t()) :: Supervisor.on_start()
-  def start_link(_module, _opts \\ []), do: {:ok, spawn(fn -> Process.sleep(:infinity) end)}
+  def start_link(module, opts \\ []) do
+    children = Keyword.get(opts, :children, [])
+    opts = [strategy: :one_for_one, name: Module.concat(module, Supervisor)]
+    Supervisor.start_link(children, opts)
+  end
 
   @doc false
   @spec metric(module, DataDaemon.key(), DataDaemon.value(), DataDaemon.type(), Keyword.t()) ::

--- a/lib/data_daemon/extensions/data_dog.ex
+++ b/lib/data_daemon/extensions/data_dog.ex
@@ -38,6 +38,10 @@ defmodule DataDaemon.Extensions.DataDog do
   defp add_event_opt(:alert_type, type, event), do: [event, "|t:", to_string(type)]
 
   @doc false
+  @spec child_spec(module, Keyword.t()) :: false
+  def child_spec(_daemon, _opts \\ []), do: false
+
+  @doc false
   @spec init(module, Keyword.t()) :: :ok
   def init(daemon, opts \\ []) do
     handler =

--- a/lib/data_daemon/extensions/vm.ex
+++ b/lib/data_daemon/extensions/vm.ex
@@ -3,13 +3,19 @@ defmodule DataDaemon.Extensions.VM do
   use GenServer
 
   @doc false
-  @spec init(module, Keyword.t()) :: :ok
-  def init(daemon, opts) do
+  @spec child_spec(module, Keyword.t()) :: map
+  def child_spec(daemon, opts \\ []) do
     opts = opts[:erlang_vm] || []
-    GenServer.start_link(__MODULE__, daemon: daemon, rate: opts[:rate] || 60_000)
 
-    :ok
+    %{
+      id: Module.concat(daemon, VM),
+      start: {GenServer, :start_link, [__MODULE__, [daemon: daemon, rate: opts[:rate] || 60_000]]}
+    }
   end
+
+  @doc false
+  @spec init(module, Keyword.t()) :: :ok
+  def init(_daemon, _opts), do: :ok
 
   # Not needed
   @doc false

--- a/lib/data_daemon/test_daemon.ex
+++ b/lib/data_daemon/test_daemon.ex
@@ -4,8 +4,18 @@ defmodule DataDaemon.TestDaemon do
 
   @doc false
   @spec start_link(module, Keyword.t()) :: Supervisor.on_start()
-  def start_link(module, _opts \\ []),
-    do: Agent.start_link(fn -> [] end, name: module)
+  def start_link(module, opts \\ []) do
+    children = [
+      %{
+        id: State,
+        start: {Agent, :start_link, [fn -> [] end, [name: module]]}
+      }
+      | Keyword.get(opts, :children, [])
+    ]
+
+    opts = [strategy: :one_for_one, name: Module.concat(module, Supervisor)]
+    Supervisor.start_link(children, opts)
+  end
 
   @doc false
   @spec metric(module, DataDaemon.key(), DataDaemon.value(), DataDaemon.type(), Keyword.t()) ::

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DataDaemon.MixProject do
   def project do
     [
       app: :data_daemon,
-      version: "0.2.0",
+      version: "0.2.1",
       description: "An Elixir StatsD client made for DataDog.",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Mostly bugfix release.

New features:

* `:minimum_ttl` option to set a minimum TTL to prevent excessive refreshing. (Default: `1_000`)

Optimizations:

* `:erlang_vm` extension runs as additional child to restart during crashes.
* Perform actual resolve in async process to prevent deadlock during excessive DNS refresh.
* DNS resolves in separate process removing use of `:timer` and only sending an update to workers if `IP` changes.

Bug fixes:

* Fixes issue where the `:erlang_vm` would link its process not to the DataDaemon, but the calling process.
