### PR TITLE
bugfix: changing iolist to binary for to_string to support weird characters

### DIFF
--- a/lib/data_daemon/extensions/data_dog.ex
+++ b/lib/data_daemon/extensions/data_dog.ex
@@ -161,7 +161,7 @@ defmodule DataDaemon.Extensions.DataDog do
       unless Logger.compare_levels(min_level, level) == :gt do
         level = translate_level(level)
         {{year, month, day}, {hour, minute, second, _millisecond}} = timestamp
-        message = if is_list(message), do: :erlang.iolist_to_binary(message), else: message
+        message = if is_list(message), do: to_string(message), else: message
 
         ts =
           :calendar.datetime_to_gregorian_seconds({{year, month, day}, {hour, minute, second}}) -

--- a/test/data_daemon/extensions/data_dog_error_handler_test.exs
+++ b/test/data_daemon/extensions/data_dog_error_handler_test.exs
@@ -65,6 +65,14 @@ defmodule DataDaemon.Extensions.DataDogErrorHandlerTest do
         assert event =~ ~r/\|t:info/
       end)
     end
+
+    test "handles weird characters in the io list" do
+      Logger.info([8880])
+
+      TestDaemon.assert_reported(Example, fn event ->
+        assert event =~ ~r/⊰/
+      end)
+    end
   end
 
   describe "general handler" do


### PR DESCRIPTION
The error handler extension is crashing when receiving weird characters as part of the iolist.

```
iex(59)> to_string([8880])
"⊰"
iex(60)> :erlang.iolist_to_binary([8880])
** (ArgumentError) argument error
    :erlang.iolist_to_binary([8880])
```

Using to_string instead fixes it.